### PR TITLE
Removed duplicate call to TypedMedia

### DIFF
--- a/Helper/MediaHelper.cs
+++ b/Helper/MediaHelper.cs
@@ -11,7 +11,7 @@
             var media = umbracoHelper.TypedMedia(mediaId);
             if (media != null)
             {
-                var output = new S3PublishedContent(umbracoHelper.TypedMedia(mediaId));
+                var output = new S3PublishedContent(media);
                 output.Url = string.Format("{0}{1}", GlobalHelper.GetCdnDomain(), output.Url());
                 return output;
             }


### PR DESCRIPTION
Been doing some profiling on a project using this tool and found within the call trace that the call to TypedMedia is (relatively) expensive.  Doesn't look like you need to do it twice here.
